### PR TITLE
Add Pagination to Report Data Renders

### DIFF
--- a/src/rss/deps.py
+++ b/src/rss/deps.py
@@ -1,9 +1,10 @@
 from typing import AsyncGenerator, Callable, Generator, Optional
 
 from arq import create_pool
-from fastapi import Query as FAQuery
+from fastapi import Query
 from redcap.project import Project
-from sqlalchemy.orm import Session, Query
+from sqlalchemy import Select
+from sqlalchemy.orm import Session
 
 from rss.db.session import SessionLocal
 from rss.models.event import Event
@@ -18,9 +19,7 @@ from rss.view_models import event, instrument
 
 
 class PaginatedParams:
-    def __init__(
-        self, page: int = FAQuery(1, ge=1), per_page: int = FAQuery(2500, ge=0)
-    ):
+    def __init__(self, page: int = Query(1, ge=1), per_page: int = Query(2500, ge=0)):
         self.page = page
         self.per_page = per_page
         self.limit = per_page * page
@@ -59,14 +58,22 @@ async def get_queue() -> AsyncGenerator:
 
 
 def get_event_calculator() -> (
-    Optional[Callable[[Session, Query[Event], list[str]], list[event.Event]]]
+    Optional[
+        Callable[
+            [Session, Select[tuple[Event]], list[str], PaginatedParams],
+            list[event.Event],
+        ]
+    ]
 ):
     return None
 
 
 def get_instrument_calculator() -> (
     Optional[
-        Callable[[Session, Query[Instrument], list[str]], list[instrument.Instrument]]
+        Callable[
+            [Session, Select[tuple[Instrument]], list[str], PaginatedParams],
+            list[instrument.Instrument],
+        ]
     ]
 ):
     return None

--- a/src/rss/deps.py
+++ b/src/rss/deps.py
@@ -1,6 +1,7 @@
 from typing import AsyncGenerator, Callable, Generator, Optional
 
 from arq import create_pool
+from fastapi import Query as FAQuery
 from redcap.project import Project
 from sqlalchemy.orm import Session, Query
 
@@ -14,6 +15,16 @@ from rss.view_models import event, instrument
 ########################################################
 # Core Dependencies
 ########################################################
+
+
+class PaginatedParams:
+    def __init__(
+        self, page: int = FAQuery(1, ge=1), per_page: int = FAQuery(2500, ge=0)
+    ):
+        self.page = page
+        self.per_page = per_page
+        self.limit = per_page * page
+        self.offset = (page - 1) * per_page
 
 
 def get_db() -> Generator:
@@ -48,9 +59,7 @@ async def get_queue() -> AsyncGenerator:
 
 
 def get_event_calculator() -> (
-    Optional[
-        Callable[[Session, Query[Event], list[str]], list[event.Event]]
-    ]
+    Optional[Callable[[Session, Query[Event], list[str]], list[event.Event]]]
 ):
     return None
 

--- a/src/rss/lib/middlewares.py
+++ b/src/rss/lib/middlewares.py
@@ -1,0 +1,15 @@
+from contextvars import ContextVar
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+
+request_object: ContextVar[Request] = ContextVar("request")
+
+
+class PaginationMiddleware(BaseHTTPMiddleware):
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        request_object.set(request)
+        response = await call_next(request)
+        return response

--- a/src/rss/lib/pagination.py
+++ b/src/rss/lib/pagination.py
@@ -1,0 +1,71 @@
+from typing import Optional
+from sqlalchemy import Select, func, select
+from sqlalchemy.orm import Session
+
+from rss.lib.middlewares import request_object
+from rss.deps import PaginatedParams
+
+
+class Paginator:
+    def __init__(self, session: Session, query: Select, page_params: PaginatedParams):
+        self.session = session
+        self.query = query
+        self.params = page_params
+        self.request = request_object.get()
+
+        # computed later
+        self.number_of_pages = 0
+        self.next_page = ""
+        self.previous_page = ""
+
+    def _get_next_page(self) -> Optional[str]:
+        if self.params.page >= self.number_of_pages:
+            return
+
+        url = self.request.url.include_query_params(page=self.params.page + 1)
+        return str(url)
+
+    def _get_previous_page(self) -> Optional[str]:
+        if self.params.page == 1 or self.params.page > self.number_of_pages + 1:
+            return
+
+        url = self.request.url.include_query_params(page=self.params.page - 1)
+        return str(url)
+
+    def get_response(self) -> dict:
+        return {
+            "count": self._get_total_count(),
+            "next_page": self._get_next_page(),
+            "previous_page": self._get_previous_page(),
+            "items": [
+                row
+                for row in self.session.scalars(
+                    self.query.limit(self.params.limit).offset(self.params.offset)
+                )
+            ],
+        }
+
+    def _get_number_of_pages(self, count: int) -> int:
+        rest = count % self.params.per_page
+        quotient = count // self.params.per_page
+        return quotient if not rest else quotient + 1
+
+    def _get_total_count(self) -> int:
+        count = self.session.scalar(
+            select(func.count()).select_from(self.query.subquery())
+        )
+
+        if not count:
+            count = 0
+
+        self.number_of_pages = self._get_number_of_pages(count)
+        return count
+
+
+def paginate(
+    db: Session,
+    query: Select,
+    page_params: PaginatedParams,
+) -> dict:
+    paginator = Paginator(db, query, page_params)
+    return paginator.get_response()

--- a/src/rss/lib/report.py
+++ b/src/rss/lib/report.py
@@ -1,0 +1,111 @@
+from sqlalchemy import tuple_, any_, select, Select
+from sqlalchemy.orm import Session, selectinload
+
+from typing import Union, Callable
+
+from rss import deps
+from rss.lib.exceptions.report import NoCustomCalculatorError
+from rss.lib.querybuilder.filter import filter
+from rss.models.event import Event
+from rss.models.instrument import Instrument
+from rss.models.project_event import ProjectEvent
+from rss.models.project_field import ProjectField
+from rss.models.project_instrument import ProjectInstrument
+from rss.models.report import Report
+from rss.view_models import event, instrument
+
+
+def construct_report_select(
+    db: Session,
+    report: Report,
+    model: type[Union[Event, Instrument]],
+    field_calculator: Callable[
+        [
+            Session,
+            Select[tuple[Union[Instrument, Event]]],
+            list[str],
+            deps.PaginatedParams,
+        ],
+        list[Union[instrument.Instrument, event.Event]],
+    ],
+    page_params: deps.PaginatedParams,
+) -> tuple[
+    Select[tuple[Union[Event, Instrument]]],
+    list[Union[instrument.Instrument, event.Event]],
+]:
+    # subqueryload and selectinload have similar performance, and both are improvements over a
+    # joinedload. Both are better than lazy loading in this scenario, since we are guaranteed to
+    # have to load relationships while json encoding. We use selectin here because it is
+    # compatible with batching, which may need to be implemented in the future.
+    # See: https://docs.sqlalchemy.org/en/13/orm/loading_relationships.html#select-in-loading
+    report_query = select(model).options(selectinload("*"))
+
+    # TODO: Can we do this later so that the filter function can do less work? (probably not)
+    if report.filters:
+        matching_rows = [(row[0],) for row in filter(db, report.filters)]
+
+        # Subset by filtered record_ids up front to ease burden on future queries. Our
+        # goal here isn't to prune the data fields into what the user wants, but rather
+        # to only surface records that match user provided filters.
+        report_query = report_query.where(
+            tuple_(model.record_id) == (any_(matching_rows))  # type: ignore
+        )
+
+    # Filter by user requested records
+    if report.records:
+        report_query = report_query.where(model.record_id.in_(report.records))
+
+    # TODO: If a lower level filter is applied, we need to perform joins for the higher
+    #       level fields as well. If only a higher level field is applied, we can stop
+    #       at that field.
+    if any([report.events, report.instruments, report.fields]):
+        report_query = (
+            report_query.join(ProjectEvent, onclause=ProjectEvent.id == model.event_id)
+            .join(
+                ProjectInstrument,
+                onclause=ProjectInstrument.id == model.instrument_id,
+            )
+            .join(ProjectField)
+        )
+
+    # Filter by user requested instruments, events, and fields.
+    if report.events:
+        report_query = report_query.where(ProjectEvent.name.in_(report.events))
+
+    if report.instruments:
+        report_query = report_query.where(
+            ProjectInstrument.name.in_(report.instruments)
+        )
+
+    # TODO: This method of calculating report data on paginated queries might have the result of
+    #       calculating the same data twice if some events are within one batch and some are within
+    #       another. We should paginated via record_ids, rather than pk ids/rows.
+    if report.calculated_instrument_fields and field_calculator is None:
+        raise NoCustomCalculatorError(
+            "Calculated instrument fields are defined on this report, but no field calculator was provided."
+        )
+
+    elif model == Event and report.calculated_event_fields and field_calculator:
+        calculated_report_data = field_calculator(
+            db, report_query, report.calculated_event_fields, page_params
+        )
+    elif (
+        model == Instrument and report.calculated_instrument_fields and field_calculator
+    ):
+        calculated_report_data = field_calculator(
+            db, report_query, report.calculated_instrument_fields, page_params
+        )
+    else:
+        calculated_report_data = []
+
+    if report.fields:
+        report_query = report_query.where(ProjectField.name.in_(report.fields))
+
+    return report_query, calculated_report_data
+
+
+def filter_item_fields(item_fields: list[str], response_data: dict):
+    for row in response_data["items"]:
+        row.data = {
+            field: row.data[field] for field in item_fields if field in row.data
+        }

--- a/src/rss/routers/report.py
+++ b/src/rss/routers/report.py
@@ -1,26 +1,23 @@
 from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.encoders import jsonable_encoder
-from sqlalchemy import tuple_, any_
-from sqlalchemy.orm import Session, selectinload, Query
+from sqlalchemy import Select, select
+from sqlalchemy.orm import Session
 
-from typing import Union, Callable, Optional
+from typing import Callable, Optional
 
 from rss import deps
 from rss.lib.authorization import (
     require_authorized_editor,
     require_authorized_viewer,
 )
-from rss.lib.exceptions.report import NoCustomCalculatorError
-from rss.lib.querybuilder.filter import filter
+from rss.lib.pagination import paginate
+from rss.lib.report import filter_item_fields, construct_report_select
 from rss.models.event import Event
 from rss.models.instrument import Instrument
-from rss.models.project_event import ProjectEvent
-from rss.models.project_field import ProjectField
-from rss.models.project_instrument import ProjectInstrument
 from rss.models.report import Report
 from rss.models.user import User
-from rss.view_models import event, instrument, report
+from rss.view_models import event, instrument, report, pagination
 
 # Router for handling all interactions with REDCap
 router = APIRouter(
@@ -153,141 +150,94 @@ def modify_report(
 
 # TODO: Do we want to implement some sort of pagination to deal with the above...
 @router.get(
-    "/render/{uuid}",
+    "/events/{uuid}",
     status_code=200,
-    response_model=tuple[list[event.Event], list[instrument.Instrument]],
-    # response_class=ORJSONResponse,
+    response_model=pagination.PaginatedResponse[event.Event],
     responses={404: {}},
 )
-def render_report(
+def render_report_events(
     uuid: UUID,
     db: Session = Depends(deps.get_db),
     user: User = Depends(require_authorized_viewer),
+    page_params: deps.PaginatedParams = Depends(),
     event_field_calculator: Optional[
-        Callable[[Session, Query[Event], list[str]], list[event.Event]]
+        Callable[
+            [Session, Select[tuple[Event]], list[str], deps.PaginatedParams],
+            list[event.Event],
+        ]
     ] = Depends(deps.get_event_calculator),
-    instrument_field_calculator: Optional[
-        Callable[[Session, Query[Instrument], list[str]], list[instrument.Instrument]]
-    ] = Depends(deps.get_instrument_calculator),
-) -> tuple[
-    list[Union[Event, event.Event]], list[Union[Instrument, instrument.Instrument]]
-]:
+) -> pagination.PaginatedResponse[event.Event]:
     """
     Lists all reports currently stored in the database.
     """
-    item = db.query(Report).filter(Report.uuid == uuid).one_or_none()
+    item = db.scalars(select(Report).where(Report.uuid == uuid)).one_or_none()
 
     if not item:
         raise HTTPException(404, "The requested report {uuid} could not be found.")
 
-    # subqueryload and selectinload have similar performance, and both are improvements over a
-    # joinedload. Both are better than lazy loading in this scenario, since we are guaranteed to
-    # have to load relationships while json encoding. We use selectin here because it is
-    # compatible with batching, which may need to be implemented in the future.
-    # See: https://docs.sqlalchemy.org/en/13/orm/loading_relationships.html#select-in-loading
-    event_data = db.query(Event).options(selectinload("*"))
-    instrument_data = db.query(Instrument).options(selectinload("*"))
+    event_select, calculated_events = construct_report_select(
+        db, item, Event, event_field_calculator, page_params
+    )
+    response_data = paginate(db, event_select, page_params)
 
-    # TODO: Can we do this later so that the filter function can do less work?
-    if item.filters:
-        matching_rows = [(row[0],) for row in filter(db, item.filters)]
-
-        # Subset by filtered record_ids up front to ease burden on future queries. Our
-        # goal here isn't to prune the data fields into what the user wants, but rather
-        # to only surface records that match user provided filters.
-        event_data = event_data.filter(tuple_(Event.record_id) == (any_(matching_rows)))  # type: ignore
-        instrument_data = instrument_data.filter(
-            tuple_(Instrument.record_id) == (any_(matching_rows))  # type: ignore
-        )
-
-    # Filter by user requested records
-    if item.records:
-        event_data = event_data.filter(Event.record_id.in_(item.records))
-        instrument_data = instrument_data.filter(Instrument.record_id.in_(item.records))
-
-    # TODO: If a lower level filter is applied, we need to perform joins for the higher
-    #       level fields as well. If only a higher level field is applied, we can stop
-    #       at that field.
-    if any([item.events, item.instruments, item.fields]):
-        event_data = (
-            event_data.join(ProjectEvent, onclause=ProjectEvent.id == Event.event_id)
-            .join(
-                ProjectInstrument, onclause=ProjectInstrument.id == Event.instrument_id
-            )
-            .join(ProjectField)
-        )
-        instrument_data = (
-            instrument_data.join(
-                ProjectEvent, onclause=ProjectEvent.id == Instrument.event_id
-            )
-            .join(
-                ProjectInstrument,
-                onclause=ProjectInstrument.id == Instrument.instrument_id,
-            )
-            .join(ProjectField)
-        )
-
-    # Filter by user requested instruments, events, and fields.
-    if item.events:
-        event_data = event_data.filter(ProjectEvent.name.in_(item.events))
-        instrument_data = instrument_data.filter(ProjectEvent.name.in_(item.events))
-
-    if item.instruments:
-        event_data = event_data.filter(ProjectInstrument.name.in_(item.instruments))
-        instrument_data = instrument_data.filter(
-            ProjectInstrument.name.in_(item.instruments)
-        )
-
-    # TODO: Allow calculated fields to be included within filter logic.
-    if item.calculated_event_fields and event_field_calculator is None:
-        raise NoCustomCalculatorError(
-            "Calculated event fields are defined on this report, but no field calculator was provided."
-        )
-
-    elif item.calculated_event_fields and event_field_calculator:
-        calculated_event_data = event_field_calculator(
-            db, event_data, item.calculated_event_fields
-        )
-    else:
-        calculated_event_data = []
-
-    if item.calculated_instrument_fields and instrument_field_calculator is None:
-        raise NoCustomCalculatorError(
-            "Calculated instrument fields are defined on this report, but no field calculator was provided."
-        )
-
-    elif item.calculated_instrument_fields and instrument_field_calculator:
-        calculated_instrument_data = instrument_field_calculator(
-            db, instrument_data, item.calculated_instrument_fields
-        )
-    else:
-        calculated_instrument_data = []
-
+    # Done filtering queries, so pull out field values. The report only needs to return
+    # rows given by the `fields` subset.
+    #
+    # NOTE: This MUST be done last since this logic has the side-effect of modifying any `.data`
+    #       field that it touches. Ie: If a calculated field relies on some event field that
+    #       we are not returning to the user, the field will not be present in the data model
+    #       if this logic occurs prior to the calculated field calculations.
     if item.fields:
-        event_data = event_data.filter(ProjectField.name.in_(item.fields))
-        instrument_data = instrument_data.filter(ProjectField.name.in_(item.fields))
+        filter_item_fields(item.fields, response_data)
 
-        # Done filtering queries, so pull out field values. The report only needs to return
-        # rows given by the `fields` subset.
-        #
-        # NOTE: This MUST be done last since this logic has the side-effect of modifying any `.data`
-        #       field that it touches. Ie: If a calculated field relies on some event field that
-        #       we are not returning to the user, the field will not be present in the data model
-        #       if this logic occurs prior to the calculated field calculations.
-        for row in event_data:
-            row.data = {
-                field: row.data[field] for field in item.fields if field in row.data
-            }
-        for row in instrument_data:
-            row.data = {
-                field: row.data[field] for field in item.fields if field in row.data
-            }
+    # Full response data is a combination of calculated and REDCap based events
+    response_data["items"] = [*response_data["items"], *calculated_events]
 
-    return [*event_data.all(), *calculated_event_data], [
-        *instrument_data.all(),
-        *calculated_instrument_data,
-    ]
+    return response_data
 
 
-def format_report_field():
-    pass
+@router.get(
+    "/instruments/{uuid}",
+    status_code=200,
+    response_model=pagination.PaginatedResponse[instrument.Instrument],
+    responses={404: {}},
+)
+def render_report_instruments(
+    uuid: UUID,
+    db: Session = Depends(deps.get_db),
+    user: User = Depends(require_authorized_viewer),
+    page_params: deps.PaginatedParams = Depends(),
+    instrument_field_calculator: Optional[
+        Callable[
+            [Session, Select[tuple[Instrument]], list[str], deps.PaginatedParams],
+            list[instrument.Instrument],
+        ]
+    ] = Depends(deps.get_instrument_calculator),
+) -> pagination.PaginatedResponse[instrument.Instrument]:
+    """
+    Lists all reports currently stored in the database.
+    """
+    item = db.scalars(select(Report).where(Report.uuid == uuid)).one_or_none()
+
+    if not item:
+        raise HTTPException(404, "The requested report {uuid} could not be found.")
+
+    instrument_select, calculated_instruments = construct_report_select(
+        db, item, Instrument, instrument_field_calculator, page_params
+    )
+    response_data = paginate(db, instrument_select, page_params)
+
+    # Done filtering queries, so pull out field values. The report only needs to return
+    # rows given by the `fields` subset.
+    #
+    # NOTE: This MUST be done last since this logic has the side-effect of modifying any `.data`
+    #       field that it touches. Ie: If a calculated field relies on some event field that
+    #       we are not returning to the user, the field will not be present in the data model
+    #       if this logic occurs prior to the calculated field calculations.
+    if item.fields:
+        filter_item_fields(item.fields, response_data)
+
+    # Full response data is a combination of calculated and REDCap based events
+    response_data["items"] = [*response_data["items"], *calculated_instruments]
+
+    return response_data

--- a/src/rss/server_main.py
+++ b/src/rss/server_main.py
@@ -7,6 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from requests import Request
 from starlette import status
 from starlette.responses import JSONResponse
+from rss.lib.middlewares import PaginationMiddleware
 from rss.routers import (
     report,
     project,
@@ -30,6 +31,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+app.add_middleware(PaginationMiddleware)
 
 app.include_router(ping.router)
 app.include_router(queue.router)
@@ -38,12 +40,13 @@ app.include_router(report.router)
 app.include_router(project.router)
 app.include_router(user.router)
 
+
 @app.exception_handler(NoCustomCalculatorError)
 async def validation_exception_handler(request: Request, exc: NoCustomCalculatorError):
     return JSONResponse(
-        status_code=status.HTTP_501_NOT_IMPLEMENTED,
-        content={"message": str(exc)}
+        status_code=status.HTTP_501_NOT_IMPLEMENTED, content={"message": str(exc)}
     )
+
 
 # If the application is not already being run within a uvicorn server, start it here.
 if __name__ == "__main__":

--- a/src/rss/view_models/pagination.py
+++ b/src/rss/view_models/pagination.py
@@ -1,0 +1,12 @@
+from typing import Optional, Generic, TypeVar, List
+from pydantic import AnyHttpUrl, BaseModel
+
+
+M = TypeVar("M")
+
+
+class PaginatedResponse(BaseModel, Generic[M]):
+    count: int
+    items: List[M]
+    next_page: Optional[AnyHttpUrl]
+    previous_page: Optional[AnyHttpUrl]


### PR DESCRIPTION
Adds pagination to report data rendering. This pagination feature is generic, and can be placed over the top of other router endpoints as needed in the future. For now, it is only used to paginate report data.